### PR TITLE
make SQS credentials optional in config

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,8 +66,8 @@ sqs_config =
       main_queue_url: System.fetch_env!("HTTP_PUSH_VIA_SQS_QUEUE_URL"),
       dlq_url: System.fetch_env!("HTTP_PUSH_VIA_SQS_DLQ_URL"),
       region: System.fetch_env!("HTTP_PUSH_VIA_SQS_REGION"),
-      access_key_id: System.fetch_env!("HTTP_PUSH_VIA_SQS_ACCESS_KEY_ID"),
-      secret_access_key: System.fetch_env!("HTTP_PUSH_VIA_SQS_SECRET_ACCESS_KEY")
+      access_key_id: System.get_env("HTTP_PUSH_VIA_SQS_ACCESS_KEY_ID"),
+      secret_access_key: System.get_env("HTTP_PUSH_VIA_SQS_SECRET_ACCESS_KEY")
     }
   end
 


### PR DESCRIPTION
## Summary
- Change `HTTP_PUSH_VIA_SQS_ACCESS_KEY_ID` and `HTTP_PUSH_VIA_SQS_SECRET_ACCESS_KEY` from `fetch_env!` to `get_env`
- Allows application to use IAM roles instead of requiring explicit credentials

Fixes INFRA-541

## Test plan
- [x] Compiles with `MIX_ENV=prod mix compile --warnings-as-errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)