### PR TITLE
use task role credentials in http_push_sqs_pipeline

### DIFF
--- a/lib/sequin/aws/client.ex
+++ b/lib/sequin/aws/client.ex
@@ -33,7 +33,17 @@ defmodule Sequin.Aws.Client do
     end
   end
 
-  defp get_credentials do
+  @doc """
+  Fetches AWS credentials from the ECS task role or other configured sources.
+
+  Returns `{:ok, credentials}` where credentials is a map containing:
+  - `:access_key_id`
+  - `:secret_access_key`
+  - `:token` (optional, for temporary credentials)
+
+  Returns `{:error, reason}` if credentials cannot be obtained.
+  """
+  def get_credentials do
     case Application.ensure_all_started(:aws_credentials) do
       {:ok, _} ->
         case :aws_credentials.get_credentials() do


### PR DESCRIPTION
## Summary
- Make `get_credentials/0` public in `Sequin.Aws.Client`
- Add `resolve_aws_credentials/2` helper to fall back to ECS task role when explicit credentials not provided
- Includes session token support for temporary credentials

Fixes INFRA-542

## Test plan
- [x] Compiles with `MIX_ENV=prod mix compile --warnings-as-errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)