### PR TITLE
expose get_credentials in Sequin.Aws behaviour

### DIFF
--- a/lib/sequin/aws/aws.ex
+++ b/lib/sequin/aws/aws.ex
@@ -7,6 +7,22 @@ defmodule Sequin.Aws do
   """
 
   @callback get_client(String.t()) :: {:ok, AWS.Client.t()} | {:error, Sequin.Error.t()}
+  @callback get_credentials() :: {:ok, map()} | {:error, Sequin.Error.t()}
+
+  @doc """
+  Fetches AWS credentials from the ECS task role or other configured sources.
+
+  Returns `{:ok, credentials}` where credentials is a map containing:
+  - `:access_key_id`
+  - `:secret_access_key`
+  - `:token` (optional, for temporary credentials)
+
+  Returns `{:error, reason}` if credentials cannot be obtained.
+  """
+  @spec get_credentials() :: {:ok, map()} | {:error, Sequin.Error.t()}
+  def get_credentials do
+    impl().get_credentials()
+  end
 
   @doc """
   Gets an AWS client configured with task role credentials.

--- a/lib/sequin/aws/client.ex
+++ b/lib/sequin/aws/client.ex
@@ -43,6 +43,7 @@ defmodule Sequin.Aws.Client do
 
   Returns `{:error, reason}` if credentials cannot be obtained.
   """
+  @impl Sequin.Aws
   def get_credentials do
     case Application.ensure_all_started(:aws_credentials) do
       {:ok, _} ->

--- a/lib/sequin/runtime/http_push_sqs_pipeline.ex
+++ b/lib/sequin/runtime/http_push_sqs_pipeline.ex
@@ -433,7 +433,7 @@ defmodule Sequin.Runtime.HttpPushSqsPipeline do
       ]
     else
       # Fetch credentials from ECS task role
-      case Sequin.Aws.Client.get_credentials() do
+      case Sequin.Aws.get_credentials() do
         {:ok, credentials} ->
           config = [
             access_key_id: Map.fetch!(credentials, :access_key_id),


### PR DESCRIPTION
## Summary
- Add `get_credentials/0` callback to `Sequin.Aws` behaviour
- Add `get_credentials/0` wrapper function to `Sequin.Aws` module for mockability
- Update `http_push_sqs_pipeline` to use `Sequin.Aws.get_credentials()` instead of calling `Sequin.Aws.Client` directly

Fixes INFRA-544

## Test plan
- [x] Compiles with `MIX_ENV=prod mix compile --warnings-as-errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)