### PR TITLE
feat: make slot supervisor start_children concurrency configurable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -89,6 +89,9 @@ config :sequin, Sequin.Runtime.SlotProcessorServer,
   max_heartbeat_emission_interval_min: ConfigParser.max_heartbeat_emission_interval_min(env_vars) || 5,
   max_heartbeat_receive_timeout_min: ConfigParser.max_heartbeat_receive_timeout_min(env_vars) || 10
 
+config :sequin, Sequin.Runtime.SlotSupervisor,
+  start_children_concurrency: String.to_integer(System.get_env("SLOT_START_CHILDREN_CONCURRENCY", "10"))
+
 # ## Using releases
 #
 # If you use `mix release`, you need to explicitly enable the server

--- a/lib/sequin/runtime/slot_supervisor.ex
+++ b/lib/sequin/runtime/slot_supervisor.ex
@@ -14,6 +14,12 @@ defmodule Sequin.Runtime.SlotSupervisor do
 
   require Logger
 
+  def config do
+    Application.get_env(:sequin, __MODULE__, [])
+  end
+
+  def setting_start_children_concurrency, do: Keyword.get(config(), :start_children_concurrency, 10)
+
   def via_tuple(id) do
     {:via, :syn, {:replication, {__MODULE__, id}}}
   end
@@ -67,7 +73,7 @@ defmodule Sequin.Runtime.SlotSupervisor do
         if test_pid = opts[:test_pid], do: Sandbox.allow(Sequin.Repo, test_pid, self())
         start_stores_and_pipeline!(consumer, opts)
       end,
-      max_concurrency: 10,
+      max_concurrency: setting_start_children_concurrency(),
       timeout: to_timeout(second: 20)
     )
     |> Enum.each(fn


### PR DESCRIPTION
## Summary
- Add `SLOT_START_CHILDREN_CONCURRENCY` env var to control `max_concurrency` when starting slot children
- Defaults to 10 (existing behavior)

## Test plan
- [ ] Deploy to dev and verify slot supervisor starts correctly
- [ ] Test with custom concurrency value

🤖 Generated with [Claude Code](https://claude.com/claude-code)