### PR TITLE
fix: upgrade minimatch to 9.0.9 (CVE-2026-27904)

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2234,12 +2234,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"


### PR DESCRIPTION
## Summary
- Upgrades transitive dependency `minimatch` from 9.0.5 to 9.0.9 to fix ReDoS vulnerability (CVE-2026-27904)
- Dependency chain: `tailwindcss` → `sucrase` → `glob` → `minimatch`

Fixes INFRA-1849

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency bump; main impact is potential build/test behavior changes from updated `minimatch`/`brace-expansion` resolution.
> 
> **Overview**
> Updates the frontend lockfile to pull in `minimatch` `9.0.9` (from `9.0.5`) and bumps its transitive `brace-expansion` requirement, addressing the referenced ReDoS CVE.
> 
> No application/runtime code changes; only dependency resolution in `assets/package-lock.json` is affected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 672e592935943830d94141e64800fb2ac81ecca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->