### PR TITLE
Fix SlotProducer walsender connection leak on connect failure

### DIFF
--- a/lib/sequin/runtime/slot_producer/slot_producer.ex
+++ b/lib/sequin/runtime/slot_producer/slot_producer.ex
@@ -252,11 +252,14 @@ defmodule Sequin.Runtime.SlotProducer do
       {:noreply, [], state}
     else
       error ->
-        reason =
+        {reason, protocol} =
           case error do
-            {:error, msg} -> msg
-            {:error, msg, %Protocol{}} -> msg
+            {:error, msg} -> {msg, nil}
+            {:error, msg, %Protocol{} = p} -> {msg, p}
+            {:disconnect, msg, %Protocol{} = p} -> {msg, p}
           end
+
+        if protocol, do: Protocol.disconnect(%RuntimeError{}, protocol)
 
         error_msg = if is_exception(reason), do: Exception.message(reason), else: inspect(reason)
         Logger.error("[SlotProducer] replication connect failed: #{error_msg}")
@@ -632,19 +635,19 @@ defmodule Sequin.Runtime.SlotProducer do
             cursor = %{commit_lsn: Postgres.lsn_to_int(lsn), commit_idx: 0}
             {:ok, %{state | restart_wal_cursor: cursor}, protocol}
 
-          {:ok, _res} ->
+          {:ok, _res, protocol} ->
             {:error,
              Error.not_found(
                entity: :source_replication_slot,
                message: "Error fetching metadata about the replication slot from Postgres"
-             )}
+             ), protocol}
 
-          error ->
+          {_error_or_disconnect, err, protocol} ->
             {:error,
              Error.service(
                service: :source_postgres,
-               message: "Error fetching metadata about the replication slot from Postgres (#{inspect(error)})"
-             )}
+               message: "Error fetching metadata about the replication slot from Postgres (#{inspect(err)})"
+             ), protocol}
         end
 
       {:ok, cursor} ->


### PR DESCRIPTION
## Summary
- When `Protocol.connect` succeeds but a later step fails (slot doesn't exist, streaming fails, etc.), the protocol connection was never closed -- leaking a walsender slot on PG each retry
- `init_restart_wal_cursor` had a dead code path (`{:ok, _res}` never matched 3-tuples from `handle_simple`) and discarded the protocol on error paths
- Discovered during PG 13->17 B/G upgrade: all 20 `max_wal_senders` were consumed by zombie connections from Sequin crash loop

Fixes INFRA-2329

## Test plan
- [ ] Verify compile passes with `MIX_ENV=prod mix compile --warnings-as-errors`
- [ ] Existing SlotProducer tests pass
- [ ] Manual: confirm walsender count does not grow on repeated connect failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PostgreSQL replication connection lifecycle and error handling; a mistake could cause reconnect loops or dropped replication streams, but the change is localized to connect/setup paths.
> 
> **Overview**
> Fixes a walsender leak during `SlotProducer` startup by ensuring any partially-established `Postgrex.Protocol` connection is explicitly `Protocol.disconnect/2`’d when later setup steps fail.
> 
> Tightens `init_restart_wal_cursor/2` error handling to correctly match `handle_simple/3`’s 3-tuple returns and to propagate the `protocol` through error paths (including `:disconnect`), so callers can cleanly tear down the connection on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f33a21e5d3e92d90c825417c6a15f931854ba68c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->