### PR TITLE
Skip periodic Redis cursor write when SlotProducer is disconnected

### DIFF
--- a/lib/sequin/runtime/slot_producer/slot_producer.ex
+++ b/lib/sequin/runtime/slot_producer/slot_producer.ex
@@ -301,6 +301,11 @@ defmodule Sequin.Runtime.SlotProducer do
     send_ack(state)
   end
 
+  def handle_info(:update_restart_wal_cursor, %State{status: :disconnected} = state) do
+    state = schedule_update_cursor(%{state | restart_wal_cursor_update_timer: nil})
+    {:noreply, [], state}
+  end
+
   def handle_info(:update_restart_wal_cursor, %State{} = state) do
     state = update_restart_wal_cursor(state)
 


### PR DESCRIPTION
## Summary
- When the replication slot is dropped (e.g. during Aurora PG upgrades), SlotProducer disconnects but the 10s periodic `:update_restart_wal_cursor` timer keeps firing, re-persisting the stale in-memory cursor to Redis
- Adds a guard clause to skip the Redis write when `status: :disconnected`, matching the existing `:send_ack` pattern
- On reconnect, `init_restart_wal_cursor` hits a Redis miss and falls back to the slot's fresh `restart_lsn`

This enables a safer Aurora upgrade flow where Sequin can stay running: drop slot → switchover → clear Redis → recreate slot → Sequin reconnects with clean state.

Related to INFRA-1233

## Test plan
- [ ] Verify compilation passes (`MIX_ENV=prod mix compile --warnings-as-errors`)
- [ ] Run slot_producer tests in CI
- [ ] Manual verification during next Aurora upgrade: confirm Sequin stays up and picks up fresh LSN after slot recreation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a disconnected guard to prevent periodic Redis cursor writes when the replication connection is down, without changing active replication behavior.
> 
> **Overview**
> Prevents `SlotProducer` from persisting `restart_wal_cursor` to Redis while `status: :disconnected` by adding a dedicated `handle_info(:update_restart_wal_cursor, ...)` clause that only reschedules the timer.
> 
> This avoids repeatedly rewriting a stale in-memory cursor during slot drop/reconnect scenarios, aligning cursor updates with the existing disconnected behavior for `:send_ack`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d95d5ef412cefe8cab4bfdac7863bf01a1f9bd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->