### PR TITLE
Upgrade brace-expansion to 2.0.3 (CVE-2026-33750)

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1047,9 +1047,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"


### PR DESCRIPTION
## Summary
- Upgrades `brace-expansion` from 2.0.2 to 2.0.3 in `assets/package-lock.json` to resolve CVE-2026-33750 (DoS via zero-step sequences)
- Build-time only transitive dep (`tailwindcss → sucrase → glob → minimatch → brace-expansion`), not reachable at runtime

Fixes INFRA-2446

## Test plan
- [x] `npm run tsc` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump; low risk aside from potential build/install determinism changes.
> 
> **Overview**
> Updates the `assets/package-lock.json` entry for `brace-expansion` from `2.0.2` to `2.0.3` (updated tarball URL and integrity hash) to pick up the security fix for CVE-2026-33750.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4094750a7f9f6840d655bba0cbd9e942a77d36e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->