### PR TITLE
Upgrade picomatch and yaml in assets (CVE-2026-33671, CVE-2026-33672, CVE-2026-33532)

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2402,9 +2402,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -3317,14 +3318,18 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
-      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Upgrades `picomatch` from 2.3.1 to 2.3.2 — fixes ReDoS (CVE-2026-33671) and method injection (CVE-2026-33672)
- Upgrades `yaml` from 2.5.0 to 2.8.3 — fixes stack overflow via deeply nested collections (CVE-2026-33532)
- Both are build-time only transitive deps in `assets/package-lock.json`

Fixes INFRA-2497, INFRA-2499, INFRA-2502

## Test plan
- [x] `npm run tsc` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency bumps; main risk is build/tooling incompatibility if downstream tooling depends on older `yaml`/`picomatch` behavior or Node version constraints.
> 
> **Overview**
> Updates `assets/package-lock.json` to bump transitive build-time dependencies: `picomatch` from `2.3.1` to `2.3.2` and `yaml` from `2.5.0` to `2.8.3` (including updated integrity/resolved metadata and `yaml`’s Node engine constraint to `>=14.6`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d3cab1abab42b088c2d6607d439bfd96f0e38e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->