### PR TITLE
Upgrade lodash-es to 4.18.1 (CVE-2026-2950, CVE-2026-4800)

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2144,9 +2144,10 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",


### PR DESCRIPTION
## Summary
- Upgrades `lodash-es` from 4.17.21 to 4.18.1 in `assets/package-lock.json`
- Fixes CVE-2026-2950 (Prototype Pollution via `_.unset`/`_.omit`) and CVE-2026-4800 (Code Injection via `_.template`)
- Transitive dep of `@getkoala/browser`

Fixes INFRA-2639, INFRA-2634

## Test plan
- [x] `npm run tsc` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency update; primary risk is minor build/runtime behavior differences from the new `lodash-es` version.
> 
> **Overview**
> Upgrades the locked `lodash-es` package from `4.17.21` to `4.18.1` in `assets/package-lock.json` (including updated tarball metadata), to pick up the newer patched release used transitively by `@getkoala/browser`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bd18ddfc162b114cf31dff7d92e2503318078c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->