### PR TITLE
Remove unused lodash dependency (CVE-2026-2950, CVE-2026-4800)

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -20,7 +20,6 @@
         "d3": "^7.9.0",
         "date-fns": "^3.6.0",
         "live_svelte": "file:../deps/live_svelte",
-        "lodash": "^4.17.21",
         "lucide-svelte": "^0.428.0",
         "marked": "^15.0.6",
         "mode-watcher": "^0.4.1",
@@ -2137,11 +2136,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -34,7 +34,6 @@
     "d3": "^7.9.0",
     "date-fns": "^3.6.0",
     "live_svelte": "file:../deps/live_svelte",
-    "lodash": "^4.17.21",
     "lucide-svelte": "^0.428.0",
     "marked": "^15.0.6",
     "mode-watcher": "^0.4.1",


### PR DESCRIPTION
## Summary
- Removes `lodash` from `assets/package.json` — it was a direct dependency but never imported anywhere
- Resolves CVE-2026-2950 (Prototype Pollution) and CVE-2026-4800 (Code Injection)

Fixes INFRA-2673, INFRA-2672

## Test plan
- [x] `npm run tsc` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency cleanup: removes an unused direct dependency and its lockfile entry, with no functional code changes.
> 
> **Overview**
> Removes `lodash` as a direct dependency from `assets/package.json` and prunes its `node_modules/lodash` entry from `assets/package-lock.json` to eliminate the vulnerable/unused package while leaving other transitive lodash-* utilities intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e30c4b489d1d193afc460d6545972037ec8d197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->