### PR TITLE
Remove unused uuid dependency from assets

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -30,14 +30,12 @@
         "svelte-sonner": "^0.3.27",
         "tailwind-merge": "^2.5.2",
         "tailwind-variants": "^0.2.1",
-        "uuid": "^10.0.0",
         "vaul-svelte": "^0.3.2"
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.14",
         "@types/node": "^22.5.0",
-        "@types/uuid": "^10.0.0",
         "autoprefixer": "^10.4.20",
         "esbuild": "^0.16.17",
         "esbuild-plugin-import-glob": "^0.1.1",
@@ -874,12 +872,6 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.12.1",
@@ -3172,18 +3164,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vaul-svelte": {
       "version": "0.3.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -3,7 +3,6 @@
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.14",
     "@types/node": "^22.5.0",
-    "@types/uuid": "^10.0.0",
     "autoprefixer": "^10.4.20",
     "esbuild": "^0.16.17",
     "esbuild-plugin-import-glob": "^0.1.1",
@@ -44,7 +43,6 @@
     "svelte-sonner": "^0.3.27",
     "tailwind-merge": "^2.5.2",
     "tailwind-variants": "^0.2.1",
-    "uuid": "^10.0.0",
     "vaul-svelte": "^0.3.2"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- `uuid` and `@types/uuid` were declared in `assets/package.json` but never imported in source code
- Removing them resolves Dependabot alerts for GHSA-w5hq-g745-h8pq (silent partial buffer writes when `v3`/`v5`/`v6` are called with caller-supplied buffer)
- Same pattern as the recent unused-lodash removal

Fixes INFRA-3501
Fixes INFRA-3500

## Test plan
- [x] `npm run format:check` passes
- [x] `npm run tsc` passes
- [x] No source files import `uuid` (verified via grep across `assets/svelte/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency-only change removing unused `uuid` packages; runtime behavior should be unchanged unless some external tooling relied on `uuid` being present.
> 
> **Overview**
> Removes `uuid` and `@types/uuid` from `assets/package.json` and prunes their entries from `assets/package-lock.json`.
> 
> This reduces the dependency surface (and associated advisories) without changing application code or behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a58e337db35527b20ab24098f992001d0932fde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->