### PR TITLE
Upgrade postcss to 8.5.14

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2419,9 +2419,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary
- Bumps `postcss` 8.5.6 → 8.5.14 in `assets/package-lock.json`
- Resolves Dependabot alert #73 / GHSA-qx2v-qp2m-jg93 (XSS via unescaped `</style>` in stringify output)
- postcss is used only at build time to process internal Tailwind CSS — vuln not reachable in this codebase, but upgrade is in-range of `^8.4.41` and trivial

Fixes INFRA-3554

## Test plan
- [x] `npm run format:check` passes
- [x] `npm run tsc` passes
- [x] `node build.js` produces unchanged CSS output (33.7kb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to `assets/package-lock.json`; impact should be confined to build-time CSS processing, though minor output differences are possible.
> 
> **Overview**
> Upgrades the locked `postcss` version from `8.5.6` to `8.5.14` in `assets/package-lock.json`, updating the resolved tarball and integrity metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce13580d72c238a4c6ae2b74aaef0eaf322ddf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->