### PR TITLE
Clamp replication slot cursor to current WAL end to prevent slot poisoning

### DIFF
--- a/lib/sequin/health/event.ex
+++ b/lib/sequin/health/event.ex
@@ -37,7 +37,8 @@ defmodule Sequin.Health.Event do
     :replication_heartbeat_received,
     :replication_heartbeat_verification,
     :replication_memory_limit_exceeded,
-    :replication_lag_checked
+    :replication_lag_checked,
+    :replication_cursor_clamped
   ]
 
   @sink_consumer_event_slugs [

--- a/lib/sequin/health/health.ex
+++ b/lib/sequin/health/health.ex
@@ -594,6 +594,7 @@ defmodule Sequin.Health do
     messages_processed_event = find_event(events, :replication_message_processed)
     heartbeat_recv_event = find_event(events, :replication_heartbeat_received)
     replication_lag_checked_event = find_event(events, :replication_lag_checked)
+    cursor_clamped_event = find_event(events, :replication_cursor_clamped)
 
     no_recent_heartbeats? =
       is_nil(heartbeat_recv_event) or Time.before_min_ago?(heartbeat_recv_event.last_event_at, 10)
@@ -619,6 +620,15 @@ defmodule Sequin.Health do
              DateTime.after?(messages_processed_event.last_event_at, heartbeat_recv_event.last_event_at)) ->
         put_check_timestamps(%{base_check | status: :error, error: messages_processed_event.error}, [
           messages_processed_event
+        ])
+
+      # Sequin recently refused to advance the slot cursor past the server's WAL end, which means
+      # the source LSN was reset (major-version blue/green upgrade, snapshot restore, or PITR).
+      # Surface it while it is recent; it auto-clears once clamping stops being re-emitted.
+      not is_nil(cursor_clamped_event) and cursor_clamped_event.status == :warning and
+          not Time.before_min_ago?(cursor_clamped_event.last_event_at, 30) ->
+        put_check_timestamps(%{base_check | status: :warning, error: cursor_clamped_event.error}, [
+          cursor_clamped_event
         ])
 
       not is_nil(replication_lag_checked_event) and replication_lag_checked_event.status == :warning ->

--- a/lib/sequin/metrics/prometheus.ex
+++ b/lib/sequin/metrics/prometheus.ex
@@ -368,7 +368,11 @@ defmodule Sequin.Prometheus do
     Gauge.set([name: :sequin_messages_buffered, labels: [consumer_id, consumer_name]], count)
   end
 
-  @spec set_slot_processor_server_busy_percent(replication_slot_id :: String.t(), slot_name :: String.t(), percent :: number()) ::
+  @spec set_slot_processor_server_busy_percent(
+          replication_slot_id :: String.t(),
+          slot_name :: String.t(),
+          percent :: number()
+        ) ::
           :ok
   def set_slot_processor_server_busy_percent(replication_slot_id, slot_name, percent) do
     Gauge.set([name: :sequin_slot_processor_server_busy_percent, labels: [replication_slot_id, slot_name]], percent)

--- a/lib/sequin/runtime/slot_producer/slot_producer.ex
+++ b/lib/sequin/runtime/slot_producer/slot_producer.ex
@@ -362,7 +362,8 @@ defmodule Sequin.Runtime.SlotProducer do
   @ignoreable_messages [?Y, ?T, ?O]
   defp handle_copies(copies, %State{} = state) do
     Enum.reduce_while(copies, {:ok, state}, fn copy, {:ok, state} ->
-      {type, msg} = parse_copy(copy)
+      {type, msg, msg_wal_end} = parse_copy(copy)
+      state = maybe_update_wal_end(state, msg_wal_end)
 
       case handle_data(type, msg, state) do
         {:ok, next_state} ->
@@ -380,13 +381,19 @@ defmodule Sequin.Runtime.SlotProducer do
     end)
   end
 
-  defp parse_copy(<<?w, _header::192, msg::binary>>) do
+  @doc false
+  # The XLogData (?w) header carries the server's current end of WAL on every data message. We
+  # surface it so wal_end stays fresh between keepalives -- otherwise a healthy slot under load can
+  # have its restart cursor wrongly clamped for "outrunning" a stale wal_end. Keepalives (?k)
+  # update wal_end in their own handle_data clause, so we return nil for them here. Public so the
+  # header byte offsets (easy to miscount) can be unit-tested directly.
+  def parse_copy(<<?w, _wal_start::64, wal_end::64, _clock::64, msg::binary>>) do
     <<type, _::binary>> = msg
-    {type, msg}
+    {type, msg, wal_end}
   end
 
-  defp parse_copy(<<?k, _rest::binary>> = msg) do
-    {?k, msg}
+  def parse_copy(<<?k, _rest::binary>> = msg) do
+    {?k, msg, nil}
   end
 
   defp handle_data(type, _msg, %State{} = state) when type in @ignoreable_messages do
@@ -537,39 +544,56 @@ defmodule Sequin.Runtime.SlotProducer do
         next_cursor -> next_cursor
       end
 
-    if not is_nil(state.restart_wal_cursor) and
-         Postgres.compare_wal_cursors(restart_wal_cursor, state.restart_wal_cursor) == :lt do
-      raise "New restart cursor is behind new restart cursor: #{inspect(restart_wal_cursor)} < #{inspect(state.restart_wal_cursor)}"
-    end
+    cond do
+      # The cursor we are already holding is itself ahead of the server's current WAL end. That
+      # means the source LSN was reset on a live connection (no reconnect to trigger init-time
+      # recovery). The candidate from the message store can legitimately be lower than the held
+      # cursor in this state, so neither the monotonicity assertion below nor advancing the cursor
+      # is valid here -- both would crash the producer. Hold position and surface the clamp;
+      # recovery happens when the connection recycles and init re-seeds the cursor from the slot.
+      not is_nil(state.restart_wal_cursor) and cursor_ahead_of_wal_end?(state.restart_wal_cursor, state.wal_end) ->
+        Logger.warning(
+          "[SlotProducer] Holding restart cursor: current cursor #{state.restart_wal_cursor.commit_lsn} is " <>
+            "ahead of current WAL end #{state.wal_end}; likely an LSN reset on the source database",
+          held_commit_lsn: state.restart_wal_cursor.commit_lsn,
+          wal_end: state.wal_end
+        )
 
-    if is_nil(restart_wal_cursor) or is_nil(restart_wal_cursor.commit_lsn) or is_nil(restart_wal_cursor.commit_idx) do
-      raise "[SlotProducer] restart_wal_cursor is empty"
-    end
+        put_cursor_clamped_event(state, state.restart_wal_cursor.commit_lsn)
+        state
 
-    if cursor_ahead_of_wal_end?(restart_wal_cursor, state.wal_end) do
-      # The candidate cursor is ahead of the server's current WAL end. This is physically
-      # impossible under normal operation and indicates the source LSN was reset (e.g. an Aurora
-      # blue/green major-version upgrade, snapshot restore, or PITR). Acking it would advance
-      # confirmed_flush_lsn past the WAL the server actually holds and silently drop every
-      # post-reset write. Hold the cursor at its current (valid) position instead.
-      #
-      # The candidate typically comes from a stale-high commit_lsn on a message still buffered in
-      # the message store. Those buffered payloads are still valid and are delivered downstream
-      # untouched; only the slot ack is clamped here.
-      Logger.warning(
-        "[SlotProducer] Refusing to advance restart cursor past current WAL end " <>
-          "(candidate=#{restart_wal_cursor.commit_lsn} wal_end=#{state.wal_end}); likely an LSN reset on the source database",
-        candidate_commit_lsn: restart_wal_cursor.commit_lsn,
-        wal_end: state.wal_end
-      )
+      not is_nil(state.restart_wal_cursor) and
+          Postgres.compare_wal_cursors(restart_wal_cursor, state.restart_wal_cursor) == :lt ->
+        raise "New restart cursor is behind new restart cursor: #{inspect(restart_wal_cursor)} < #{inspect(state.restart_wal_cursor)}"
 
-      put_cursor_clamped_event(state, restart_wal_cursor.commit_lsn)
+      is_nil(restart_wal_cursor) or is_nil(restart_wal_cursor.commit_lsn) or is_nil(restart_wal_cursor.commit_idx) ->
+        raise "[SlotProducer] restart_wal_cursor is empty"
 
-      state
-    else
-      Replication.put_restart_wal_cursor!(state.id, restart_wal_cursor)
+      cursor_ahead_of_wal_end?(restart_wal_cursor, state.wal_end) ->
+        # The candidate cursor is ahead of the server's current WAL end. This is physically
+        # impossible under normal operation and indicates the source LSN was reset (e.g. an Aurora
+        # blue/green major-version upgrade, snapshot restore, or PITR). Acking it would advance
+        # confirmed_flush_lsn past the WAL the server actually holds and silently drop every
+        # post-reset write. Hold the cursor at its current (valid) position instead.
+        #
+        # The candidate typically comes from a stale-high commit_lsn on a message still buffered in
+        # the message store. Those buffered payloads are still valid and are delivered downstream
+        # untouched; only the slot ack is clamped here.
+        Logger.warning(
+          "[SlotProducer] Refusing to advance restart cursor past current WAL end " <>
+            "(candidate=#{restart_wal_cursor.commit_lsn} wal_end=#{state.wal_end}); likely an LSN reset on the source database",
+          candidate_commit_lsn: restart_wal_cursor.commit_lsn,
+          wal_end: state.wal_end
+        )
 
-      %{state | restart_wal_cursor: restart_wal_cursor}
+        put_cursor_clamped_event(state, restart_wal_cursor.commit_lsn)
+
+        state
+
+      true ->
+        Replication.put_restart_wal_cursor!(state.id, restart_wal_cursor)
+
+        %{state | restart_wal_cursor: restart_wal_cursor}
     end
   end
 
@@ -673,7 +697,7 @@ defmodule Sequin.Runtime.SlotProducer do
         restart_lsn = if not is_nil(restart_lsn), do: Postgres.lsn_to_int(restart_lsn)
         current_wal_lsn = if not is_nil(current_wal_lsn), do: Postgres.lsn_to_int(current_wal_lsn)
 
-        resolve_init_restart_wal_cursor(%{state | wal_end: current_wal_lsn}, restart_lsn, current_wal_lsn, protocol)
+        resolve_init_restart_wal_cursor(%{state | wal_end: current_wal_lsn}, restart_lsn, protocol)
 
       {:ok, _res, protocol} ->
         {:error, Error.not_found(entity: :source_replication_slot), protocol}
@@ -687,19 +711,20 @@ defmodule Sequin.Runtime.SlotProducer do
     end
   end
 
-  defp resolve_init_restart_wal_cursor(%State{} = state, restart_lsn, current_wal_lsn, protocol) do
+  defp resolve_init_restart_wal_cursor(%State{} = state, restart_lsn, protocol) do
     case Replication.restart_wal_cursor(state.id) do
       {:error, %NotFoundError{}} ->
         # No cached cursor: seed from the slot's actual restart_lsn (Postgres' own position).
         if is_nil(restart_lsn) do
           {:error, Error.not_found(entity: :source_replication_slot), protocol}
         else
-          {:ok, %{state | restart_wal_cursor: %{commit_lsn: restart_lsn, commit_idx: 0}}, protocol}
+          {:ok,
+           %{state | restart_wal_cursor: %{commit_lsn: bound_lsn_by_wal_end(restart_lsn, state.wal_end), commit_idx: 0}},
+           protocol}
         end
 
       {:ok, cursor} ->
-        {:ok, %{state | restart_wal_cursor: clamp_cached_init_cursor(state, cursor, restart_lsn, current_wal_lsn)},
-         protocol}
+        {:ok, %{state | restart_wal_cursor: clamp_cached_init_cursor(state, cursor, restart_lsn)}, protocol}
     end
   end
 
@@ -708,17 +733,17 @@ defmodule Sequin.Runtime.SlotProducer do
   # post-reset change as "below the restart cursor", silently dropping data. Discard it and fall
   # back to the slot's real position (restart_lsn), which self-heals on any LSN reset. When we
   # cannot determine the WAL end (current_wal_lsn is nil), keep the cached cursor unchanged.
-  defp clamp_cached_init_cursor(%State{} = state, cursor, restart_lsn, current_wal_lsn) do
-    if cursor_ahead_of_wal_end?(cursor, current_wal_lsn) do
-      fallback_lsn = restart_lsn || current_wal_lsn
+  defp clamp_cached_init_cursor(%State{} = state, cursor, restart_lsn) do
+    if cursor_ahead_of_wal_end?(cursor, state.wal_end) do
+      fallback_lsn = bound_lsn_by_wal_end(restart_lsn, state.wal_end)
       fallback = %{commit_lsn: fallback_lsn, commit_idx: 0}
 
       Logger.warning(
         "[SlotProducer] Discarding cached restart cursor ahead of current WAL end " <>
-          "(cached=#{cursor.commit_lsn} wal_end=#{current_wal_lsn}); falling back to slot position #{fallback_lsn}. " <>
+          "(cached=#{cursor.commit_lsn} wal_end=#{state.wal_end}); falling back to slot position #{fallback_lsn}. " <>
           "Likely an LSN reset on the source database.",
         cached_commit_lsn: cursor.commit_lsn,
-        wal_end: current_wal_lsn,
+        wal_end: state.wal_end,
         restart_lsn: restart_lsn,
         fallback_commit_lsn: fallback_lsn
       )
@@ -812,6 +837,22 @@ defmodule Sequin.Runtime.SlotProducer do
   defp cursor_ahead_of_wal_end?(_cursor, nil), do: false
   defp cursor_ahead_of_wal_end?(%{commit_lsn: commit_lsn}, wal_end), do: commit_lsn > wal_end
 
+  # Track the latest server-reported WAL end. We deliberately SET rather than take the max: a
+  # genuine LSN reset lowers the server's WAL end, and the clamp can only detect a now-ahead cursor
+  # if wal_end is allowed to follow the server down. Within a single connection the server's WAL
+  # end is monotonic, so this only ever moves backwards across a reset.
+  defp maybe_update_wal_end(%State{} = state, nil), do: state
+  defp maybe_update_wal_end(%State{} = state, wal_end), do: %{state | wal_end: wal_end}
+
+  # Never seed or fall back to an LSN ahead of the server's current WAL end. On a consistent server
+  # restart_lsn is already <= current WAL, but a restored/rewound slot could in principle report
+  # otherwise; bounding it keeps a poisoned cursor from sneaking back through the fallback path. A
+  # nil wal_end (unknown -- e.g. a standby) leaves the lsn untouched. Public for unit tests.
+  @doc false
+  def bound_lsn_by_wal_end(lsn, nil), do: lsn
+  def bound_lsn_by_wal_end(nil, wal_end), do: wal_end
+  def bound_lsn_by_wal_end(lsn, wal_end), do: min(lsn, wal_end)
+
   defp put_cursor_clamped_event(%State{} = state, cursor_commit_lsn) do
     error =
       Error.service(
@@ -835,32 +876,48 @@ defmodule Sequin.Runtime.SlotProducer do
   end
 
   defp send_ack(%State{} = state) do
-    delta =
-      case state.last_sent_restart_wal_cursor do
-        nil -> 0
-        last_sent -> state.restart_wal_cursor.commit_lsn - last_sent.commit_lsn
+    if cursor_ahead_of_wal_end?(state.restart_wal_cursor, state.wal_end) do
+      # Never transmit a confirmed_flush_lsn ahead of the server's current WAL end. The persist
+      # path (update_restart_wal_cursor) already refuses to advance restart_wal_cursor past
+      # wal_end, but a cursor advanced before an in-place LSN reset (no reconnect) could still be
+      # sitting in state. Hold the ack until wal_end catches up or the connection recycles and
+      # init re-seeds the cursor from the slot.
+      Logger.warning(
+        "[SlotProducer] Holding ack: restart cursor #{state.restart_wal_cursor.commit_lsn} is ahead of " <>
+          "current WAL end #{state.wal_end}; not advancing confirmed_flush_lsn",
+        restart_commit_lsn: state.restart_wal_cursor.commit_lsn,
+        wal_end: state.wal_end
+      )
+
+      {:noreply, [], state}
+    else
+      delta =
+        case state.last_sent_restart_wal_cursor do
+          nil -> 0
+          last_sent -> state.restart_wal_cursor.commit_lsn - last_sent.commit_lsn
+        end
+
+      if delta < 0 do
+        raise """
+          Was about to send lower restart_wal_cursor:
+            restart_wal_cursor=#{inspect(state.restart_wal_cursor)}
+            last_sent_restart_wal_cursor=#{inspect(state.last_sent_restart_wal_cursor)}
+        """
       end
 
-    if delta < 0 do
-      raise """
-        Was about to send lower restart_wal_cursor:
-          restart_wal_cursor=#{inspect(state.restart_wal_cursor)}
-          last_sent_restart_wal_cursor=#{inspect(state.last_sent_restart_wal_cursor)}
-      """
-    end
+      Logger.info("[SlotProducer] Sending ack for LSN #{state.restart_wal_cursor.commit_lsn} (+#{delta})",
+        delta_bytes: delta
+      )
 
-    Logger.info("[SlotProducer] Sending ack for LSN #{state.restart_wal_cursor.commit_lsn} (+#{delta})",
-      delta_bytes: delta
-    )
+      msg = ack_message(state.restart_wal_cursor.commit_lsn)
 
-    msg = ack_message(state.restart_wal_cursor.commit_lsn)
+      case Protocol.handle_copy_send(msg, state.protocol) do
+        :ok ->
+          {:noreply, [], %{state | last_sent_restart_wal_cursor: state.restart_wal_cursor}}
 
-    case Protocol.handle_copy_send(msg, state.protocol) do
-      :ok ->
-        {:noreply, [], %{state | last_sent_restart_wal_cursor: state.restart_wal_cursor}}
-
-      {error, reason, protocol} ->
-        handle_disconnect(error, reason, %{state | protocol: protocol})
+        {error, reason, protocol} ->
+          handle_disconnect(error, reason, %{state | protocol: protocol})
+      end
     end
   end
 

--- a/lib/sequin/runtime/slot_producer/slot_producer.ex
+++ b/lib/sequin/runtime/slot_producer/slot_producer.ex
@@ -125,6 +125,13 @@ defmodule Sequin.Runtime.SlotProducer do
       field :ack_timer, reference()
       field :last_dispatched_wal_cursor, Replication.wal_cursor()
 
+      # Latest "current end of WAL" reported by the server (seeded by the init query, then
+      # refreshed by every keepalive). Used to clamp the restart cursor so we never persist or
+      # ack an LSN ahead of WAL the server has actually generated. A cursor ahead of current WAL
+      # is physically impossible and poisons the slot after an LSN reset (a major-version
+      # blue/green upgrade, snapshot restore, or PITR all reset the LSN counter to a lower value).
+      field :wal_end, integer() | nil
+
       # Batches
       field :batch_idx, BatchMarker.idx(), default: 0
 
@@ -514,7 +521,7 @@ defmodule Sequin.Runtime.SlotProducer do
       Logger.debug(log, log_meta)
     end
 
-    {:ok, state}
+    {:ok, %{state | wal_end: wal_end}}
   end
 
   defp handle_data(type, _msg, %State{} = state) do
@@ -539,9 +546,31 @@ defmodule Sequin.Runtime.SlotProducer do
       raise "[SlotProducer] restart_wal_cursor is empty"
     end
 
-    Replication.put_restart_wal_cursor!(state.id, restart_wal_cursor)
+    if cursor_ahead_of_wal_end?(restart_wal_cursor, state.wal_end) do
+      # The candidate cursor is ahead of the server's current WAL end. This is physically
+      # impossible under normal operation and indicates the source LSN was reset (e.g. an Aurora
+      # blue/green major-version upgrade, snapshot restore, or PITR). Acking it would advance
+      # confirmed_flush_lsn past the WAL the server actually holds and silently drop every
+      # post-reset write. Hold the cursor at its current (valid) position instead.
+      #
+      # The candidate typically comes from a stale-high commit_lsn on a message still buffered in
+      # the message store. Those buffered payloads are still valid and are delivered downstream
+      # untouched; only the slot ack is clamped here.
+      Logger.warning(
+        "[SlotProducer] Refusing to advance restart cursor past current WAL end " <>
+          "(candidate=#{restart_wal_cursor.commit_lsn} wal_end=#{state.wal_end}); likely an LSN reset on the source database",
+        candidate_commit_lsn: restart_wal_cursor.commit_lsn,
+        wal_end: state.wal_end
+      )
 
-    %{state | restart_wal_cursor: restart_wal_cursor}
+      put_cursor_clamped_event(state, restart_wal_cursor.commit_lsn)
+
+      state
+    else
+      Replication.put_restart_wal_cursor!(state.id, restart_wal_cursor)
+
+      %{state | restart_wal_cursor: restart_wal_cursor}
+    end
   end
 
   defp message_from_binary(%State{commit_lsn: nil}, msg) do
@@ -631,32 +660,74 @@ defmodule Sequin.Runtime.SlotProducer do
   defp maybe_toggle_buffering(%State{status: :active} = state), do: state
 
   defp init_restart_wal_cursor(%State{} = state, protocol) do
-    query = "select restart_lsn from pg_replication_slots where slot_name = '#{state.slot_name}'"
+    # Fetch the slot's restart_lsn alongside the server's current WAL end. We need both so we can
+    # (a) seed wal_end before the first keepalive arrives and (b) detect and discard a cached
+    # cursor that sits ahead of the WAL the server actually holds. The recovery-aware expression
+    # mirrors `Postgres.replication_lag_bytes/2` so the query also works on a standby.
+    query =
+      "select restart_lsn, case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end " <>
+        "from pg_replication_slots where slot_name = '#{state.slot_name}'"
 
+    case Protocol.handle_simple(query, [], protocol) do
+      {:ok, [%Postgrex.Result{rows: [[restart_lsn, current_wal_lsn]]}], protocol} ->
+        restart_lsn = if not is_nil(restart_lsn), do: Postgres.lsn_to_int(restart_lsn)
+        current_wal_lsn = if not is_nil(current_wal_lsn), do: Postgres.lsn_to_int(current_wal_lsn)
+
+        resolve_init_restart_wal_cursor(%{state | wal_end: current_wal_lsn}, restart_lsn, current_wal_lsn, protocol)
+
+      {:ok, _res, protocol} ->
+        {:error, Error.not_found(entity: :source_replication_slot), protocol}
+
+      {_error_or_disconnect, err, protocol} ->
+        {:error,
+         Error.service(
+           service: :source_postgres,
+           message: "Error fetching metadata about the replication slot from Postgres (#{inspect(err)})"
+         ), protocol}
+    end
+  end
+
+  defp resolve_init_restart_wal_cursor(%State{} = state, restart_lsn, current_wal_lsn, protocol) do
     case Replication.restart_wal_cursor(state.id) do
       {:error, %NotFoundError{}} ->
-        case Protocol.handle_simple(query, [], protocol) do
-          {:ok, [%Postgrex.Result{rows: [[lsn]]}], protocol} when not is_nil(lsn) ->
-            cursor = %{commit_lsn: Postgres.lsn_to_int(lsn), commit_idx: 0}
-            {:ok, %{state | restart_wal_cursor: cursor}, protocol}
-
-          {:ok, _res, protocol} ->
-            {:error,
-             Error.not_found(
-               entity: :source_replication_slot,
-               message: "Error fetching metadata about the replication slot from Postgres"
-             ), protocol}
-
-          {_error_or_disconnect, err, protocol} ->
-            {:error,
-             Error.service(
-               service: :source_postgres,
-               message: "Error fetching metadata about the replication slot from Postgres (#{inspect(err)})"
-             ), protocol}
+        # No cached cursor: seed from the slot's actual restart_lsn (Postgres' own position).
+        if is_nil(restart_lsn) do
+          {:error, Error.not_found(entity: :source_replication_slot), protocol}
+        else
+          {:ok, %{state | restart_wal_cursor: %{commit_lsn: restart_lsn, commit_idx: 0}}, protocol}
         end
 
       {:ok, cursor} ->
-        {:ok, %{state | restart_wal_cursor: cursor}, protocol}
+        {:ok, %{state | restart_wal_cursor: clamp_cached_init_cursor(state, cursor, restart_lsn, current_wal_lsn)},
+         protocol}
+    end
+  end
+
+  # A cached cursor ahead of the server's current WAL end can only mean the source LSN was reset
+  # (blue/green major-version upgrade, snapshot restore, PITR). Trusting it would skip every
+  # post-reset change as "below the restart cursor", silently dropping data. Discard it and fall
+  # back to the slot's real position (restart_lsn), which self-heals on any LSN reset. When we
+  # cannot determine the WAL end (current_wal_lsn is nil), keep the cached cursor unchanged.
+  defp clamp_cached_init_cursor(%State{} = state, cursor, restart_lsn, current_wal_lsn) do
+    if cursor_ahead_of_wal_end?(cursor, current_wal_lsn) do
+      fallback_lsn = restart_lsn || current_wal_lsn
+      fallback = %{commit_lsn: fallback_lsn, commit_idx: 0}
+
+      Logger.warning(
+        "[SlotProducer] Discarding cached restart cursor ahead of current WAL end " <>
+          "(cached=#{cursor.commit_lsn} wal_end=#{current_wal_lsn}); falling back to slot position #{fallback_lsn}. " <>
+          "Likely an LSN reset on the source database.",
+        cached_commit_lsn: cursor.commit_lsn,
+        wal_end: current_wal_lsn,
+        restart_lsn: restart_lsn,
+        fallback_commit_lsn: fallback_lsn
+      )
+
+      put_cursor_clamped_event(state, cursor.commit_lsn)
+
+      fallback
+    else
+      cursor
     end
   end
 
@@ -732,6 +803,34 @@ defmodule Sequin.Runtime.SlotProducer do
       :postgres_replication_slot,
       id,
       %Event{slug: :replication_connected, status: :success}
+    )
+  end
+
+  # A cursor is "ahead of WAL end" only when we have a known wal_end to compare against and the
+  # cursor's commit_lsn exceeds it. commit_idx is a Sequin-internal sub-position within a commit
+  # and has no analog in the server's wal_end, so we compare on commit_lsn alone.
+  defp cursor_ahead_of_wal_end?(_cursor, nil), do: false
+  defp cursor_ahead_of_wal_end?(%{commit_lsn: commit_lsn}, wal_end), do: commit_lsn > wal_end
+
+  defp put_cursor_clamped_event(%State{} = state, cursor_commit_lsn) do
+    error =
+      Error.service(
+        service: :postgres_replication_slot,
+        message:
+          "Sequin's replication cursor (#{cursor_commit_lsn}) is ahead of the database's current WAL end (#{state.wal_end}). " <>
+            "This means the database's LSN counter was reset — most often by a major-version blue/green upgrade, a snapshot " <>
+            "restore, or point-in-time recovery. Sequin is holding the slot at the current WAL end so it does not skip data."
+      )
+
+    Health.put_event(
+      :postgres_replication_slot,
+      state.id,
+      %Event{
+        slug: :replication_cursor_clamped,
+        status: :warning,
+        error: error,
+        extra: %{cursor_commit_lsn: cursor_commit_lsn, wal_end: state.wal_end}
+      }
     )
   end
 

--- a/test/sequin/health_test.exs
+++ b/test/sequin/health_test.exs
@@ -158,6 +158,29 @@ defmodule Sequin.HealthTest do
     end
   end
 
+  describe "replication_messages check" do
+    test "surfaces a warning when the slot cursor was recently clamped past WAL end" do
+      entity = postgres_replication()
+
+      # The messages check is only evaluated once the slot is connected.
+      :ok = Health.put_event(entity, %Event{slug: :replication_connected, status: :success})
+
+      {:ok, health} = Health.health(entity)
+      assert Enum.find(health.checks, &(&1.slug == :replication_messages)).status == :initializing
+
+      # An LSN reset (e.g. a major-version blue/green upgrade) causes SlotProducer to clamp the
+      # cursor and emit this warning rather than poisoning the slot.
+      clamp_error = ErrorFactory.service_error()
+      :ok = Health.put_event(entity, %Event{slug: :replication_cursor_clamped, status: :warning, error: clamp_error})
+
+      {:ok, health} = Health.health(entity)
+      check = Enum.find(health.checks, &(&1.slug == :replication_messages))
+      assert check.status == :warning
+      assert check.error == clamp_error
+      assert health.status == :warning
+    end
+  end
+
   describe "to_external/1" do
     test "converts the health to an external format" do
       entity = ConsumersFactory.sink_consumer(id: Factory.uuid(), inserted_at: DateTime.utc_now())

--- a/test/sequin/health_test.exs
+++ b/test/sequin/health_test.exs
@@ -179,6 +179,39 @@ defmodule Sequin.HealthTest do
       assert check.error == clamp_error
       assert health.status == :warning
     end
+
+    test "stops warning once the clamp event is older than 30 minutes" do
+      clamp_error = ErrorFactory.service_error()
+
+      # Fresh side of the 30-minute boundary: a recent clamp warning surfaces on the check.
+      fresh_entity = postgres_replication()
+      :ok = Health.put_event(fresh_entity, %Event{slug: :replication_connected, status: :success})
+
+      :ok =
+        Health.put_event(fresh_entity, %Event{slug: :replication_cursor_clamped, status: :warning, error: clamp_error})
+
+      {:ok, fresh_health} = Health.health(fresh_entity)
+      assert Enum.find(fresh_health.checks, &(&1.slug == :replication_messages)).status == :warning
+
+      # Stale side: a distinct slot whose clamp event last fired ~31 minutes ago. We backdate by
+      # traveling Sequin.utc_now/0 (which Event.set_timestamps/2 reads to stamp last_event_at)
+      # before the single emit, then restore real time. A separate entity avoids the put_event
+      # debounce, which would otherwise drop a same-hash re-emit within the debounce window.
+      stale_entity = postgres_replication()
+      :ok = Health.put_event(stale_entity, %Event{slug: :replication_connected, status: :success})
+
+      thirty_one_min_ago = DateTime.add(DateTime.utc_now(), -31, :minute)
+      stub_utc_now(fn -> thirty_one_min_ago end)
+
+      :ok =
+        Health.put_event(stale_entity, %Event{slug: :replication_cursor_clamped, status: :warning, error: clamp_error})
+
+      stub_utc_now(fn -> DateTime.utc_now() end)
+
+      # Older than the 30-minute window, the clamp warning no longer surfaces on the check.
+      {:ok, stale_health} = Health.health(stale_entity)
+      assert Enum.find(stale_health.checks, &(&1.slug == :replication_messages)).status != :warning
+    end
   end
 
   describe "to_external/1" do

--- a/test/sequin/runtime/slot_producer/slot_producer_test.exs
+++ b/test/sequin/runtime/slot_producer/slot_producer_test.exs
@@ -15,6 +15,8 @@ defmodule Sequin.Runtime.SlotProducerTest do
   alias Sequin.Factory.DatabasesFactory
   alias Sequin.Factory.ReplicationFactory
   alias Sequin.Factory.TestEventLogFactory
+  alias Sequin.Health
+  alias Sequin.Health.Event
   alias Sequin.Postgres
   alias Sequin.Replication
   alias Sequin.Runtime.SlotProducer
@@ -352,6 +354,65 @@ defmodule Sequin.Runtime.SlotProducerTest do
 
       assert msg.kind == :insert
       assert msg.payload =~ "Character 2"
+    end
+
+    @tag skip_start: true
+    test "discards a cached restart cursor ahead of WAL end at init and still delivers changes", %{
+      slot: slot,
+      db: db
+    } do
+      # Simulate the state left behind by an LSN reset (e.g. an Aurora blue/green major-version
+      # upgrade): a cached cursor far ahead of the WAL the (fresh) server actually holds.
+      {:ok, current_lsn} = Postgres.current_wal_lsn(db)
+      poisoned_lsn = current_lsn + 1_000_000_000_000
+      Replication.put_restart_wal_cursor!(slot.id, %{commit_lsn: poisoned_lsn, commit_idx: 0})
+
+      # These changes land below the poisoned cursor but above the slot's real restart_lsn.
+      for i <- 1..3 do
+        CharacterFactory.insert_character!(%{name: "Post Reset #{i}"}, repo: UnboxedRepo)
+      end
+
+      start_slot_producer(slot)
+
+      # If the cached cursor were trusted, every change would be skipped as "below the restart
+      # cursor" (silent data loss). Clamping back to the slot's real position delivers them all.
+      messages = receive_messages(3)
+      assert length(messages) == 3
+      assert Enum.all?(messages, &(&1.kind == :insert))
+      assert messages |> Enum.map(& &1.payload) |> Enum.all?(&(&1 =~ "Post Reset"))
+    end
+
+    @tag skip_start: true
+    test "refuses to advance the restart cursor past the current WAL end", %{slot: slot, db: db} do
+      {:ok, current_lsn} = Postgres.current_wal_lsn(db)
+      poisoned_lsn = current_lsn + 1_000_000_000_000
+
+      # The candidate cursor (normally derived from min_unpersisted_wal_cursor) is stale-high after
+      # a reset. Every update attempt must be clamped rather than acked.
+      start_slot_producer(slot,
+        ack_interval: 1,
+        restart_wal_cursor_update_interval: 1,
+        restart_wal_cursor_fn: fn _id, _last -> %{commit_lsn: poisoned_lsn, commit_idx: 0} end
+      )
+
+      CharacterFactory.insert_character!(%{name: "C1"}, repo: UnboxedRepo)
+      receive_messages(1)
+
+      # The clamp is surfaced via a Health event rather than silently applied or crashing.
+      assert_eventually(
+        match?(
+          {:ok, %Event{slug: :replication_cursor_clamped, status: :warning}},
+          Health.get_event(slot.id, :replication_cursor_clamped)
+        ),
+        1000
+      )
+
+      # The poisoned candidate must never reach Postgres: confirmed_flush_lsn stays at/below WAL end.
+      {:ok, wal_end} = Postgres.current_wal_lsn(db)
+      {:ok, confirmed} = Postgres.confirmed_flush_lsn(db, replication_slot())
+      assert is_integer(confirmed)
+      assert confirmed < poisoned_lsn
+      assert confirmed <= wal_end
     end
 
     @tag start_opts: [processor_opts: [consumer_demand: :manual]]

--- a/test/sequin/runtime/slot_producer/slot_producer_test.exs
+++ b/test/sequin/runtime/slot_producer/slot_producer_test.exs
@@ -380,6 +380,15 @@ defmodule Sequin.Runtime.SlotProducerTest do
       assert length(messages) == 3
       assert Enum.all?(messages, &(&1.kind == :insert))
       assert messages |> Enum.map(& &1.payload) |> Enum.all?(&(&1 =~ "Post Reset"))
+
+      # The init-time clamp is surfaced via a Health event, same as the runtime clamp path.
+      assert_eventually(
+        match?(
+          {:ok, %Event{slug: :replication_cursor_clamped, status: :warning}},
+          Health.get_event(slot.id, :replication_cursor_clamped)
+        ),
+        1000
+      )
     end
 
     @tag skip_start: true
@@ -413,6 +422,60 @@ defmodule Sequin.Runtime.SlotProducerTest do
       assert is_integer(confirmed)
       assert confirmed < poisoned_lsn
       assert confirmed <= wal_end
+    end
+
+    @tag skip_start: true
+    test "advances the cursor for a valid candidate on a healthy slot without clamping", %{
+      slot: slot,
+      db: db
+    } do
+      # Guards that the WAL-end clamp does not over-fire on healthy traffic: a candidate equal to
+      # the commit_lsn of a change the producer actually received (hence <= the WAL end the server
+      # reported on that message) must be acked, not clamped. Complements the "refuses to advance"
+      # test, which proves a genuinely-too-high candidate IS clamped. (This does not isolate the
+      # ?w-vs-keepalive wal_end source -- catch-up keepalives also keep wal_end fresh once the
+      # stream drains; the byte-level ?w extraction is covered by the parse_copy/1 unit tests.)
+      {:ok, wal_end_at_start} = Postgres.current_wal_lsn(db)
+
+      # The test supplies the restart-cursor candidate: nil (no-op) until we learn a real, delivered
+      # commit_lsn, then that commit_lsn. Driving it this way avoids depending on keepalive timing.
+      {:ok, candidate_agent} = Agent.start_link(fn -> nil end)
+
+      start_slot_producer(slot,
+        ack_interval: 5,
+        restart_wal_cursor_update_interval: 5,
+        restart_wal_cursor_fn: fn _id, _last -> Agent.get(candidate_agent, & &1) end
+      )
+
+      for i <- 1..3 do
+        CharacterFactory.insert_character!(%{name: "Healthy #{i}"}, repo: UnboxedRepo)
+      end
+
+      messages = receive_messages(3)
+      assert length(messages) == 3
+      last_commit_lsn = messages |> List.last() |> Map.fetch!(:commit_lsn)
+      # The candidate sits above the stale init wal_end (so the buggy path would clamp it)...
+      assert last_commit_lsn > wal_end_at_start
+
+      # ...but it is a position the server has written and the producer has seen, so it must NOT
+      # be treated as ahead of WAL end once wal_end tracks the ?w stream.
+      Agent.update(candidate_agent, fn _ -> %{commit_lsn: last_commit_lsn, commit_idx: 0} end)
+
+      # The cursor advances to the valid candidate: confirmed_flush_lsn moves past the stale seed.
+      # Without per-message wal_end tracking this stalls (the candidate is clamped) and times out.
+      assert_eventually(
+        case Postgres.confirmed_flush_lsn(db, replication_slot()) do
+          {:ok, confirmed} when is_integer(confirmed) -> confirmed > wal_end_at_start
+          _ -> false
+        end,
+        2000
+      )
+
+      # And no false clamp warning was emitted for this healthy slot.
+      refute match?(
+               {:ok, %Event{slug: :replication_cursor_clamped}},
+               Health.get_event(slot.id, :replication_cursor_clamped)
+             )
     end
 
     @tag start_opts: [processor_opts: [consumer_demand: :manual]]
@@ -527,6 +590,37 @@ defmodule Sequin.Runtime.SlotProducerTest do
     #   # Clean up
     #   GenStage.stop(producer_pid)
     # end
+  end
+
+  describe "parse_copy/1 (wal_end extraction)" do
+    test "extracts the server's current WAL end from an XLogData (?w) frame" do
+      # XLogData header: Byte1('w'), Int64 wal_start, Int64 wal_end, Int64 clock, then the message.
+      inner = <<?I, 1, 2, 3, 4>>
+      frame = <<?w, 4_242::64, 9_876_543::64, 111_222::64, inner::binary>>
+
+      assert {?I, ^inner, 9_876_543} = SlotProducer.parse_copy(frame)
+    end
+
+    test "reports no wal_end for a keepalive (?k) frame (the ?k handler sets it instead)" do
+      frame = <<?k, 555::64, 111::64, 0>>
+
+      assert {?k, ^frame, nil} = SlotProducer.parse_copy(frame)
+    end
+  end
+
+  describe "bound_lsn_by_wal_end/2" do
+    test "caps an lsn at the wal_end (the #6 defense-in-depth)" do
+      assert SlotProducer.bound_lsn_by_wal_end(100, 80) == 80
+      assert SlotProducer.bound_lsn_by_wal_end(60, 80) == 60
+    end
+
+    test "passes the lsn through when wal_end is unknown (e.g. a standby)" do
+      assert SlotProducer.bound_lsn_by_wal_end(100, nil) == 100
+    end
+
+    test "falls back to wal_end when the lsn is nil" do
+      assert SlotProducer.bound_lsn_by_wal_end(nil, 80) == 80
+    end
   end
 
   defp receive_messages(count, acc \\ []) do


### PR DESCRIPTION
Fixes INFRA-4277

## Problem

Sequin can poison a logical replication slot by acking a `confirmed_flush_lsn` that is **ahead of the WAL that exists on the server**. This happens whenever the source cluster's LSN counter resets to a lower value than a cursor Sequin has cached — most notably after an Aurora blue/green major-version upgrade (the green cluster starts at a low LSN), but also after a snapshot restore or PITR.

The result: every post-reset write sits *below* the poisoned floor and is silently dropped by the logical decoder. Observed on graph-node-fourth (2026-06-04): `confirmed_flush_lsn` ~80 TB ahead of `pg_current_wal_lsn`, with acked-but-never-delivered replay UPDATEs.

The only guards on `restart_wal_cursor` were **lower** bounds (reject moving backward). Nothing stopped acking past current WAL. A cursor ahead of current WAL is physically impossible, so one upper-bound invariant closes all three carryover paths (in-memory, Redis, `consumer_events`) at once.

## Fix

`lib/sequin/runtime/slot_producer/slot_producer.ex`:

- **Retain `wal_end`** — the keepalive handler already destructured the server's current WAL end but only logged it; it's now kept in `State`, and seeded at init from a current-WAL-end query (recovery-aware, mirroring `Postgres.replication_lag_bytes/2`).
- **init** — `init_restart_wal_cursor` now reads `restart_lsn` *and* current WAL end. A cached cursor `> wal_end` is discarded in favor of the slot's real `restart_lsn`. Self-heals on **any** LSN reset, not just our upgrade runbook.
- **update/ack** — `update_restart_wal_cursor` refuses to advance/persist/ack a candidate `> wal_end`; it holds the current (valid) cursor, logs loudly, and emits a Health event.

The clamp lives on the **slot-cursor path only**, never on delivery — buffered `consumer_events` payloads are still delivered after a reset (only their stale `commit_lsn` is prevented from driving the slot ack).

> Design note: the clamp bound is **current WAL end**, not `restart_lsn`. `confirmed_flush_lsn >= restart_lsn` under normal operation, so `restart_lsn` would wrongly reject valid cursors. Current WAL end is the only sound upper bound.

## Observability

New `:replication_cursor_clamped` Health event (`event.ex`), surfaced as a recency-bounded (30 min) warning on the `:replication_messages` check (`health.ex`). Makes the previously-silent failure visible and auto-clears once clamping stops being re-emitted.

## Testing

- `slot_producer_test.exs`: (a) cached cursor ahead of WAL end at init → falls back, changes still delivered (no loss); (b) candidate cursor ahead of WAL end at update → never acked (`confirmed_flush_lsn` stays ≤ WAL end) + Health event emitted.
- `health_test.exs`: clamp event surfaces as a `:replication_messages` warning.

`mix compile --warnings-as-errors` (dev + prod) and `mix format --check-formatted` pass locally. The unboxed/DataCase tests require the test Postgres, which I could not run locally (port conflict) — relying on CI.

## Rollout

- Touches the **core replication hot path for every slot and sink**. Once green + reviewed, the remaining acceptance step is validating against a B/G PG13→PG17 upgrade on a dev shard (confirm `confirmed_flush_lsn` stays ≤ `pg_current_wal_lsn` with no manual Redis/ECS intervention).
- Once validated in prod, the stopgaps become deletable: goldsky-infra#4064 (Phase 7 ECS bounce) and the INFRA-4224 drain/verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes init, cursor update, and ack behavior on every replication slot; incorrect clamping could stall acks or mis-handle cursors, though tests target both failure and healthy paths.
> 
> **Overview**
> Prevents **logical replication slot poisoning** after a source **LSN reset** (blue/green major upgrade, snapshot restore, PITR) by never persisting or acking a restart cursor **ahead of the server’s current WAL end**.
> 
> **SlotProducer** tracks `wal_end` from init (recovery-aware `restart_lsn` + current WAL query) and from replication traffic (XLogData `?w` headers and keepalives). On connect it **discards a cached cursor above `wal_end`** and re-seeds from the slot’s real position. During runtime it **refuses to advance** `restart_wal_cursor` or send **confirmed_flush_lsn** when the held or candidate cursor exceeds `wal_end`, logs warnings, and emits a new **`:replication_cursor_clamped`** health event. Downstream message delivery is unchanged; only slot ack/persist is clamped.
> 
> **Health** registers the new event slug and surfaces a **30-minute recency-bounded warning** on the `:replication_messages` check. Tests cover init/runtime clamping, healthy-slot non-clamping, `parse_copy/1`, and `bound_lsn_by_wal_end/2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb8d9193d9f2cf65b37622363bbe1906853d4bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->