### PR TITLE
Fix prod assets build: alias lodash to lodash-es for @getkoala/browser

### DIFF
--- a/assets/build.js
+++ b/assets/build.js
@@ -21,6 +21,9 @@ let optsClient = {
   sourcemap: watch ? "inline" : false,
   watch,
   tsconfig: "./tsconfig.json",
+  // @getkoala/browser's published dist imports `lodash/throttle` (CJS lodash),
+  // but we only ship the patched lodash-es. esbuild remaps subpaths too.
+  alias: { lodash: "lodash-es" },
   loader: {
     ".svg": "dataurl",
     ".mdx": "text",
@@ -63,6 +66,7 @@ let optsServer = {
   sourcemap: watch ? "inline" : false,
   watch,
   tsconfig: "./tsconfig.json",
+  alias: { lodash: "lodash-es" },
   loader: {
     ".svg": "dataurl",
     ".mdx": "text",


### PR DESCRIPTION
## Problem

The Docker prod build fails at `mix assets.deploy`:

```
✘ [ERROR] Could not resolve "lodash/throttle"
    node_modules/@getkoala/browser/dist/esm/analytics/queue.js:1:21
```

## Root cause

`@getkoala/browser@1.22.1`'s published `dist/esm` imports `lodash/throttle` (the **CJS lodash** subpath, not `lodash-es`). Commit 0e30c4b4 removed `lodash` from `assets/package.json` believing it was unused — it was actually a runtime requirement of koala.

Local builds kept passing because `node_modules` still had lodash on disk. The Docker build installs fresh, so the import can't resolve.

## Fix

Alias `lodash` → `lodash-es` in both esbuild configs in `assets/build.js`. `lodash-es` is already present (koala dependency, on the patched 4.18.1 which fixed CVE-2026-2950/4800) and esbuild remaps the `/throttle` subpath, so the build is restored **without** reintroducing the vulnerable CJS lodash.

Only `lodash/throttle` is imported by koala's JS, and `lodash-es/throttle` exposes the same default export.

## Verification

`node build.js --deploy` now bundles both client and server cleanly; `npm run format:check` passes.

Fixes INFRA-4329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/goldsky-io/codesmith/sequin/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783691391&installation_id=139361939&pr_number=45&repository=goldsky-io%2Fsequin&return_to=https%3A%2F%2Fgithub.com%2Fgoldsky-io%2Fsequin%2Fpull%2F45&signature=7474252557717cbc63e36b121a544081ec178e88ce909f08785b33867afe52ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time resolution only; no runtime auth, data, or API behavior changes beyond bundling Koala analytics.
> 
> **Overview**
> **Fixes `mix assets.deploy` / Docker prod builds** that fail when esbuild cannot resolve `lodash/throttle` from `@getkoala/browser`'s published ESM bundle after CJS `lodash` was removed from dependencies.
> 
> Adds **`alias: { lodash: "lodash-es" }`** to both the browser (`optsClient`) and SSR/node (`optsServer`) esbuild configs in `assets/build.js`, with a short comment explaining why. Subpath imports like `lodash/throttle` are remapped to the already-patched `lodash-es` tree so the vulnerable CJS `lodash` package is not reintroduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173ab15c0564944eaaeab451518d450b3eb9ae3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->